### PR TITLE
Fixed ill-formed data file saving

### DIFF
--- a/data_clusters.py
+++ b/data_clusters.py
@@ -100,6 +100,9 @@ km = KMeans(n_clusters=8, verbose=False, random_state=1, n_init=5)
 labels = km.fit_predict(timeseries_to_cluster)
 data_relevant['labels'] = labels
 
+data_relevant['cumulative_progress_weeks'] =\
+    data_relevant['cumulative_progress_weeks'].apply(lambda x: [float(n) for n in x])
+
 # save clustered data
 data_relevant.to_csv('data_relevant_clustered.csv', index=False)
 


### PR DESCRIPTION
There was a problem with saving the data_relevant dataframe to csv. Specifically, the representation of the `cumulative_progress_weeks` column was *e.g.*, `"[np.float(1.0), np.float(1.5), ...]"` instead of `"[1.0, 1.5, ...]"`.

This meant that when later scripts tried to read it back it `literal_eval` would fail. This change just turns that column from a list of np.float to a list of python floats before it is written to the file.
